### PR TITLE
Fix Logger Initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Enqueue is an MIT-licensed open source project with its ongoing development made
 [![Total Downloads](https://poser.pugx.org/enqueue/simple-client/d/total.png)](https://packagist.org/packages/enqueue/simple-client)
 [![Latest Stable Version](https://poser.pugx.org/enqueue/simple-client/version.png)](https://packagist.org/packages/enqueue/simple-client)
  
-The simple client takes Enqueue client classes and Symfony components and combines it to easy to use facade called `SimpleCLient`.   
+The simple client takes Enqueue client classes and Symfony components and combines it to easy to use facade called `SimpleClient`.   
 
 ## Resources
 

--- a/SimpleClient.php
+++ b/SimpleClient.php
@@ -126,9 +126,9 @@ final class SimpleClient
             ];
         }
 
-        $this->build(['enqueue' => $config]);
-
         $this->logger = $logger ?: new NullLogger();
+
+        $this->build(['enqueue' => $config]);
     }
 
     /**


### PR DESCRIPTION
When creating a simpleclient, the internal dependencies are initialised before the LoggerInterface passed into SimpleClient is assigned, meaning dependent objects receive a NullLogger instead.